### PR TITLE
feat(Neo4jStorage): Add target database selection for graph persistence

### DIFF
--- a/itext2kg/graph_integration/neo4j_storage.py
+++ b/itext2kg/graph_integration/neo4j_storage.py
@@ -3,6 +3,7 @@ import numpy as np
 from typing import List
 from itext2kg.models import KnowledgeGraph
 from itext2kg.logging_config import get_logger
+from typing import List, Optional
 
 logger = get_logger(__name__)
 
@@ -10,7 +11,7 @@ class Neo4jStorage:
     """
     A class to integrate and manage graph data in a Neo4j database.
     """
-    def __init__(self, uri: str, username: str, password: str):
+    def __init__(self, uri: str, username: str, password: str, database: Optional[str] = None):
         """
         Initializes the Neo4jStorage with database connection parameters.
         
@@ -18,10 +19,12 @@ class Neo4jStorage:
             uri (str): URI for the Neo4j database.
             username (str): Username for database access.
             password (str): Password for database access.
+            database (Optional[str]): The name of the database to connect to. Defaults to None, which uses the default database.
         """
         self.uri = uri
         self.username = username
         self.password = password
+        self.database = database 
         self.driver = self.connect()
         
     def connect(self):
@@ -42,7 +45,7 @@ class Neo4jStorage:
         Args:
             query (str): The Cypher query to run.
         """
-        session = self.driver.session()
+        session = self.driver.session(database=self.database)
         try:
             session.run(query)
         finally:
@@ -142,7 +145,7 @@ class Neo4jStorage:
         Returns:
             List of records from the query result.
         """
-        session = self.driver.session()
+        session = self.driver.session(database=self.database)
         try:
             result = session.run(query)
             return [record for record in result]


### PR DESCRIPTION
@lairgiyassir : Thank you for your work. I'm impressed by itext2kg, a powerful and evolving tool. I truly appreciate the dedication behind its continuous improvements. Congrat' !
_____________________________________________________________

This commit introduces the ability to specify a target database when connecting to Neo4j via the `Neo4jStorage` class.

Previously, the `Neo4jStorage` module would always connect to the default Neo4j database (typically named `neo4j`). This limitation prevented users from pushing knowledge graphs to specific, named databases within a Neo4j instance, hindering multi-database deployments and better organization of graph data.

Changes include:
- Added an optional `database: Optional[str] = None` parameter to the `Neo4jStorage` class constructor (`__init__`).
- Modified the `connect()` method to store this `database` parameter.
- Updated the `run_query()` and `run_query_with_result()` methods to pass `self.database` to the `driver.session()` call, ensuring queries are executed against the specified database.

Local testing with Neo4j Desktop v1.6.2 confirmed successful graph persistence in the correct target database when the optional argument was used, and no errors were encountered in either scenario (with or without the argument).